### PR TITLE
Fixed small error in BMI calculator basic example

### DIFF
--- a/docs/basic-examples.html
+++ b/docs/basic-examples.html
@@ -515,11 +515,11 @@ function main(sources) {
     div([
       div([
         'Weight ' + weight + 'kg',
-        input('.weight', {type: 'range', min: 40, max: 140, value: weight})
+        input('.weight', {attrs: {type: 'range', min: 40, max: 140, value: weight}})
       ]),
       div([
         'Height ' + height + 'cm',
-        input('.height', {type: 'range', min: 140, max: 210, value: height})
+        input('.height', {attrs: {type: 'range', min: 140, max: 210, value: height}})
       ]),
       h2('BMI is ' + bmi)
     ])


### PR DESCRIPTION
In the final listing of the BMI calculator basic example there is a small error with the input declaration. It's missing the attr key in the config object.

Fixes #783
